### PR TITLE
Fix RecipeParser HTML parsing

### DIFF
--- a/app/Services/RecipeParser.php
+++ b/app/Services/RecipeParser.php
@@ -10,9 +10,9 @@ class RecipeParser
 {
     public static function fetchRecipeFromUrl(string $url): array
     {
-        $html = Http::get($url);
+        $html = Http::get($url)->body();
         $dom = new DOMDocument;
-        libxml_use_internal_errors(1);
+        libxml_use_internal_errors(true);
         $dom->loadHTML($html);
         $xpath = new DOMXpath($dom);
         $jsonScripts = $xpath->query('//script[@type="application/ld+json"]');


### PR DESCRIPTION
## Summary
- load HTTP response body before passing HTML to `DOMDocument::loadHTML`

## Testing
- `npm --version` *(fails: Unknown env config) - confirm environment setup*


------
https://chatgpt.com/codex/tasks/task_e_684031fba19c8322927810ed6045e1a1