### PR TITLE
Add ingredient calculation test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ yarn-error.log
 **/caddy
 frankenphp
 frankenphp-worker.php
+
+futter_rocks.sqlite

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class EventFactory extends Factory
+{
+    protected $model = Event::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(),
+            'description' => null,
+            'date_from' => Carbon::today(),
+            'date_to' => Carbon::today()->addDay(),
+            'created_by_id' => User::factory(),
+            'team_id' => Team::factory(),
+        ];
+    }
+}

--- a/database/factories/ParticipantGroupFactory.php
+++ b/database/factories/ParticipantGroupFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ParticipantGroup;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ParticipantGroupFactory extends Factory
+{
+    protected $model = ParticipantGroup::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->word(),
+            'food_factor' => $this->faker->randomFloat(2, 0.5, 2),
+            'team_id' => Team::factory(),
+        ];
+    }
+}

--- a/tests/Unit/RecipeIngredientCalculationTest.php
+++ b/tests/Unit/RecipeIngredientCalculationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Models\Enums\Unit;
+use App\Models\Event;
+use App\Models\Ingredient;
+use App\Models\ParticipantGroup;
+use App\Models\Recipe;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+it('calculates ingredients for an event with proper units', function () {
+    $user = User::factory()->withCurrentTeam()->create();
+    actingAs($user);
+
+    $event = Event::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'created_by_id' => $user->id,
+    ]);
+
+    $group1 = ParticipantGroup::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'food_factor' => 1,
+    ]);
+    $group2 = ParticipantGroup::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'food_factor' => 2,
+    ]);
+
+    $event->participantGroups()->attach($group1, ['quantity' => 10]);
+    $event->participantGroups()->attach($group2, ['quantity' => 5]);
+
+    $recipe = Recipe::factory()->create([
+        'team_id' => $user->currentTeam->id,
+    ]);
+
+    $ingGrams = Ingredient::factory()->createQuietly();
+    $ingPieces = Ingredient::factory()->createQuietly();
+
+    $recipe->ingredients()->attach($ingGrams->id, [
+        'quantity' => 100,
+        'unit' => Unit::Grams,
+    ]);
+    $recipe->ingredients()->attach($ingPieces->id, [
+        'quantity' => 1,
+        'unit' => Unit::Pieces,
+    ]);
+
+    $recipe->load('ingredients');
+    foreach ($recipe->ingredients as $ingredient) {
+        $ingredient->unit = $ingredient->pivot->unit;
+    }
+
+    $calculated = $recipe->getCalculatedIngredientsForEvent($event);
+
+    $gramsItem = collect($calculated)->firstWhere('ingredient.id', $ingGrams->id);
+    expect($gramsItem['quantity'])->toBe(2.0)
+        ->and($gramsItem['ingredient']->unit)->toBe(Unit::Kilos);
+
+    $piecesItem = collect($calculated)->firstWhere('ingredient.id', $ingPieces->id);
+    expect($piecesItem['quantity'])->toBe(20.0)
+        ->and($piecesItem['ingredient']->unit)->toBe(Unit::Pieces);
+});


### PR DESCRIPTION
## Summary
- add factories for `Event` and `ParticipantGroup`
- ensure ingredients are loaded with units in new test
- test summation and unit conversion with `getCalculatedIngredientsForEvent`

## Testing
- `composer lint`
- `vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_6840381264948322bbb8fbda0fbf4060