### PR TITLE
feat: add Formatter unit tests

### DIFF
--- a/tests/Unit/FormatterTest.php
+++ b/tests/Unit/FormatterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Formatter;
+use Illuminate\Support\Facades\App;
+
+uses(Tests\TestCase::class);
+
+it('formats numbers according to the app locale', function () {
+    App::setLocale('de');
+
+    $formatter = new Formatter;
+
+    expect($formatter->format(1234.56))->toBe('1.234,56');
+});
+
+it('formats numbers for the en locale', function () {
+    App::setLocale('en');
+
+    $formatter = new Formatter;
+
+    expect($formatter->format(1234.56))->toBe('1,234.56');
+});
+
+it('reuses the same NumberFormatter instance', function () {
+    $formatter = new Formatter;
+
+    $instanceOne = $formatter->getFormatter();
+    $instanceTwo = $formatter->getFormatter();
+
+    expect($instanceOne)->toBe($instanceTwo);
+});


### PR DESCRIPTION
## Summary
- add new tests for the `Formatter` helper
- ensure numbers format correctly for English locale

## Testing
- `composer lint`
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68404affc7d483229d032e7c1403ea7a