### PR TITLE
fix: cast email to lowercase before inviting

### DIFF
--- a/app/Actions/Jetstream/InviteTeamMember.php
+++ b/app/Actions/Jetstream/InviteTeamMember.php
@@ -23,6 +23,7 @@ class InviteTeamMember implements InvitesTeamMembers
      */
     public function invite(User $user, Team $team, string $email, ?string $role = null): void
     {
+        $email = strtolower($email);
         Gate::forUser($user)->authorize('addTeamMember', $team);
 
         $this->validate($team, $email, $role);

--- a/tests/Feature/InviteTeamMemberTest.php
+++ b/tests/Feature/InviteTeamMemberTest.php
@@ -14,12 +14,15 @@ test('team members can be invited to team', function () {
 
     Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->set('addTeamMemberForm', [
-            'email' => 'test@example.com',
+            'email' => 'Test@Example.COM',
             'role' => 'admin',
         ])->call('addTeamMember');
 
     Mail::assertSent(TeamInvitation::class);
 
+    $invitation = $user->currentTeam->fresh()->teamInvitations->first();
+
+    expect($invitation->email)->toBe('test@example.com');
     expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(1);
 })->skip(function () {
     return ! Features::sendsTeamInvitations();


### PR DESCRIPTION
## Summary
- normalize emails when inviting a team member
- ensure team invitation email is stored in lowercase

## Testing
- `composer lint`
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_6874fbd760a883228a0874c0d1692a2c